### PR TITLE
makefile: set machine cflags

### DIFF
--- a/Makefile.lb
+++ b/Makefile.lb
@@ -3,6 +3,8 @@ include $(WORKSPACE_TOP)/common/Makefile.env
 RTE_SDK:=$(shell component-tool localpath --repo=dpdk --type=$(BUILD_TYPE) dpdk-sdk)
 SPDK_INSTALL_DIR ?= $(shell component-tool localpath --repo=spdk --type=$(BUILD_TYPE) spdk-sdk)
 
+MACHINE_CFLAGS := "-march=broadwell"
+
 all: build
 
 checkout_deps:
@@ -10,7 +12,7 @@ checkout_deps:
 
 build: checkout_deps 
 	./configure --with-dpdk=$(RTE_SDK)
-	$(Q)$(MAKE) CONFIG_DPDK_DIR=$(RTE_SDK)
+	$(Q)$(MAKE) MACHINE_CFLAGS=$(MACHINE_CFLAGS) CONFIG_DPDK_DIR=$(RTE_SDK)
 
 clean: checkout_deps 
 	$(Q)$(MAKE) CONFIG_DPDK_DIR=$(RTE_SDK) clean


### PR DESCRIPTION
In order to avoid native compiling (i.e. while compiling on skylake
machines), we need to set "-march=broadwell".

Issue: LBM1-2598