### PR TITLE
SPDK: override native compile with broadwell

### DIFF
--- a/mk/spdk.common.mk
+++ b/mk/spdk.common.mk
@@ -74,7 +74,7 @@ ifneq ($(filter powerpc%,$(TARGET_MACHINE)),)
 COMMON_CFLAGS += -mcpu=native
 endif
 ifeq ($(TARGET_MACHINE),x86_64)
-COMMON_CFLAGS += -march=native
+COMMON_CFLAGS += -march=broadwell
 endif
 
 COMMON_CFLAGS += -include $(SPDK_ROOT_DIR)/config.h


### PR DESCRIPTION
LightOs support broadwell and up (so we should avoid native copile on
skylake platform and newer)

Issue: LBM1-5757

Signed-off-by: Maor Vanmak <maor@lightbitslabs.com>