### PR TITLE
Overwrite mk/config.mk when fetching spdk from remote cache

### DIFF
--- a/Makefile.lb
+++ b/Makefile.lb
@@ -25,6 +25,7 @@ install: |checkout_deps
 	$(Q) cp -a lib $(SPDK_INSTALL_DIR)
 	$(Q) cp -a config* $(SPDK_INSTALL_DIR)
 	$(Q) cp -a include $(SPDK_INSTALL_DIR)
+	$(Q) cp -a $(WORKSPACE_TOP)/spdk/mk/config.mk $(SPDK_INSTALL_DIR)
 
 checkin: 
 	$(Q)component-tool checkin --repo=spdk --type=$(BUILD_TYPE) spdk-sdk


### PR DESCRIPTION
mk/config.mk is auto-generated with local path set to variables CONFIG_ENV and
CONFIG_DPDK_DIR.
When this file is fetched from remote, values are incorrect for local machine.
The file is also always generated locally, so I chose to overwrite it with the
local mk/config.mk when copying files into the build folder under $(SPDK_INSTALL_DIR).

After this fix I can build perftools locally, I will try to build Kernelight on jenkins during this PR.
Issue: LBM1-9685